### PR TITLE
refactor: rewrite constructor more concisely

### DIFF
--- a/src/bip32.js
+++ b/src/bip32.js
@@ -29,19 +29,15 @@ function UInt31(value) {
     return typeforce.UInt32(value) && value <= UINT31_MAX;
 }
 class BIP32 {
-    constructor(d, Q, chainCode, network) {
-        typeforce(NETWORK_TYPE, network);
+    constructor(__D, __Q, chainCode, network) {
+        this.__D = __D;
+        this.__Q = __Q;
         this.chainCode = chainCode;
+        this.network = network;
         this.depth = 0;
         this.index = 0;
-        this.network = network;
         this.parentFingerprint = 0x00000000;
-        this.__D = undefined;
-        this.__Q = undefined;
-        if (d !== undefined)
-            this.__D = d;
-        if (Q !== undefined)
-            this.__Q = Q;
+        typeforce(NETWORK_TYPE, network);
     }
     get publicKey() {
         if (this.__Q === undefined)

--- a/ts-src/bip32.ts
+++ b/ts-src/bip32.ts
@@ -68,32 +68,17 @@ export interface BIP32Interface {
 }
 
 class BIP32 implements BIP32Interface {
-  chainCode: Buffer;
-  network: Network;
-  depth: number;
-  index: number;
-  parentFingerprint: number;
-  private __D?: Buffer;
-  private __Q?: Buffer;
+  depth = 0;
+  index = 0;
+  parentFingerprint = 0x00000000;
 
   constructor(
-    d: Buffer | undefined,
-    Q: Buffer | undefined,
-    chainCode: Buffer,
-    network: Network,
+    private __D: Buffer | undefined,
+    private __Q: Buffer | undefined,
+    public chainCode: Buffer,
+    public network: Network,
   ) {
     typeforce(NETWORK_TYPE, network);
-
-    this.chainCode = chainCode;
-    this.depth = 0;
-    this.index = 0;
-    this.network = network;
-    this.parentFingerprint = 0x00000000;
-
-    this.__D = undefined;
-    this.__Q = undefined;
-    if (d !== undefined) this.__D = d;
-    if (Q !== undefined) this.__Q = Q;
   }
 
   get publicKey(): Buffer {


### PR DESCRIPTION
I prefer parameter properties because they let us create and initialize a class member in one place. 

See `Parameter properties` section in https://www.typescriptlang.org/docs/handbook/classes.html